### PR TITLE
use correct post url on social sharing buttons

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -39,7 +39,7 @@ custom_scripts: |
                         {{ page.content }}                                                    
                     </div>
                     <!--//Social media buttons: https://github.com/kni-labs/rrssb (More examples) -->
-                    {% capture url %}http://zegetech.com{{page.url}}{% endcapture %}
+                    {% capture url %}{{ page.url | absolute_url }}{% endcapture %}
                     <div class="share-container">
                         <span class="label">share this:</span>
                         <!-- Buttons start here. Copy this ul to your document. -->
@@ -73,32 +73,6 @@ custom_scripts: |
                                         </svg>
                                    </span>
                                     <span class="rrssb-text">twitter</span>
-                                </a>
-                            </li>
-                            <li class="rrssb-googleplus">
-                                <!-- Replace href with your meta and URL information.  -->
-                                <a href="https://plus.google.com/share?url={{url}}&text={{page.title}} {{url}}" class="popup">
-                                    <span class="rrssb-icon">
-                                        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="28px" height="28px" viewBox="0 0 28 28" enable-background="new 0 0 28 28" xml:space="preserve">
-                                            <g>
-                                                <g>
-                                                    <path d="M14.703,15.854l-1.219-0.948c-0.372-0.308-0.88-0.715-0.88-1.459c0-0.748,0.508-1.223,0.95-1.663
-                                                        c1.42-1.119,2.839-2.309,2.839-4.817c0-2.58-1.621-3.937-2.399-4.581h2.097l2.202-1.383h-6.67c-1.83,0-4.467,0.433-6.398,2.027
-                                                        C3.768,4.287,3.059,6.018,3.059,7.576c0,2.634,2.022,5.328,5.604,5.328c0.339,0,0.71-0.033,1.083-0.068
-                                                        c-0.167,0.408-0.336,0.748-0.336,1.324c0,1.04,0.551,1.685,1.011,2.297c-1.524,0.104-4.37,0.273-6.467,1.562
-                                                        c-1.998,1.188-2.605,2.916-2.605,4.137c0,2.512,2.358,4.84,7.289,4.84c5.822,0,8.904-3.223,8.904-6.41
-                                                        c0.008-2.327-1.359-3.489-2.829-4.731H14.703z M10.269,11.951c-2.912,0-4.231-3.765-4.231-6.037c0-0.884,0.168-1.797,0.744-2.511
-                                                        c0.543-0.679,1.489-1.12,2.372-1.12c2.807,0,4.256,3.798,4.256,6.242c0,0.612-0.067,1.694-0.845,2.478
-                                                        c-0.537,0.55-1.438,0.948-2.295,0.951V11.951z M10.302,25.609c-3.621,0-5.957-1.732-5.957-4.142c0-2.408,2.165-3.223,2.911-3.492
-                                                        c1.421-0.479,3.25-0.545,3.555-0.545c0.338,0,0.52,0,0.766,0.034c2.574,1.838,3.706,2.757,3.706,4.479
-                                                        c-0.002,2.073-1.736,3.665-4.982,3.649L10.302,25.609z"/>
-                                                    <polygon points="23.254,11.89 23.254,8.521 21.569,8.521 21.569,11.89 18.202,11.89 18.202,13.604 21.569,13.604 21.569,17.004
-                                                        23.254,17.004 23.254,13.604 26.653,13.604 26.653,11.89      "/>
-                                                </g>
-                                            </g>
-                                        </svg>
-                                    </span>
-                                    <span class="rrssb-text">google+</span>
                                 </a>
                             </li>
                             <li class="rrssb-linkedin">

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -38,7 +38,8 @@ custom_scripts: |
                     <div class="content">
                         {{ page.content }}                                                    
                     </div>
-                    <!--//Soical media buttons: https://github.com/kni-labs/rrssb (More examples) -->
+                    <!--//Social media buttons: https://github.com/kni-labs/rrssb (More examples) -->
+                    {% capture url %}http://zegetech.com{{page.url}}{% endcapture %}
                     <div class="share-container">
                         <span class="label">share this:</span>
                         <!-- Buttons start here. Copy this ul to your document. -->
@@ -46,7 +47,7 @@ custom_scripts: |
                             <li class="rrssb-facebook">
                                 <!-- Replace with your URL. For best results, make sure you page has the proper FB Open Graph tags in header:
                                 https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content/ -->
-                                <a href="https://www.facebook.com/sharer/sharer.php?u=http://zegetech.com{{page.url}}" class="popup">
+                                <a href="https://www.facebook.com/sharer/sharer.php?u={{url}}" class="popup">
                                     <span class="rrssb-icon">
                                         <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="28px" height="28px" viewBox="0 0 28 28" enable-background="new 0 0 28 28" xml:space="preserve">
                                             <path d="M27.825,4.783c0-2.427-2.182-4.608-4.608-4.608H4.783c-2.422,0-4.608,2.182-4.608,4.608v18.434
@@ -59,7 +60,7 @@ custom_scripts: |
                             </li>
                             <li class="rrssb-twitter">
                                 <!-- Replace href with your Meta and URL information  -->
-                                <a href="https://twitter.com/intent/tweet?text={{page.title}} http://zegetech.com{{page.url}}" class="popup">
+                                <a href="https://twitter.com/intent/tweet?text={{page.title}} {{url}}" class="popup">
                                     <span class="rrssb-icon">
                                         <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
                                              width="28px" height="28px" viewBox="0 0 28 28" enable-background="new 0 0 28 28" xml:space="preserve">
@@ -76,7 +77,7 @@ custom_scripts: |
                             </li>
                             <li class="rrssb-googleplus">
                                 <!-- Replace href with your meta and URL information.  -->
-                                <a href="https://plus.google.com/share?url=http://zegetech.com&text={{page.title}} http://zegetech.com{{page.url}}" class="popup">
+                                <a href="https://plus.google.com/share?url={{url}}&text={{page.title}} {{url}}" class="popup">
                                     <span class="rrssb-icon">
                                         <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="28px" height="28px" viewBox="0 0 28 28" enable-background="new 0 0 28 28" xml:space="preserve">
                                             <g>
@@ -102,7 +103,7 @@ custom_scripts: |
                             </li>
                             <li class="rrssb-linkedin">
                                 <!-- Replace href with your meta and URL information -->
-                                <a href="http://www.linkedin.com/shareArticle?mini=true&url=http://zegetech.com&title={{page.title}}&text={{page.title}} http://zegetech.com{{page.url}}" class="popup">
+                                <a href="http://www.linkedin.com/shareArticle?mini=true&url={{url}}&title={{page.title}}&text={{page.title}} {{url}}" class="popup">
                                     <span class="rrssb-icon">
                                         <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="28px" height="28px" viewBox="0 0 28 28" enable-background="new 0 0 28 28" xml:space="preserve">
                                             <path d="M25.424,15.887v8.447h-4.896v-7.882c0-1.979-0.709-3.331-2.48-3.331c-1.354,0-2.158,0.911-2.514,1.803


### PR DESCRIPTION
Updates share button urls to point to the blog post as opposed to the site root. Ensures previews are generated with the right content.