### PR TITLE
add command to index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ addons:
   apt:
     packages:
     - libcurl4-openssl-dev # required to avoid SSL errors
-    
+
 rvm:
   - 2.6.2
 
@@ -29,3 +29,6 @@ deploy:
     secure: $FIREBASE_TOKEN
   on:
     branch: release
+
+after_deploy:
+  - ALGOLIA_API_KEY=$ALGOLIA_API_KEY bundle exec jekyll algolia


### PR DESCRIPTION
Add command to push the index to algolia after a successful deploy.

`$ALGOLIA_API_KEY` variable needed in variables
